### PR TITLE
Fix Bulldogs URL typo

### DIFF
--- a/player_scraper.py
+++ b/player_scraper.py
@@ -49,7 +49,7 @@ class PlayerScraper:
         'https://afltables.com/afl/stats/alltime/stkilda.html',
         'https://afltables.com/afl/stats/alltime/swans.html',      # Sydney
         'https://afltables.com/afl/stats/alltime/westcoast.html',
-        'https://afltables.com/afl/stats/alltime/bullldogs.html',  # Western Bulldogs
+        'https://afltables.com/afl/stats/alltime/bulldogs.html',  # Western Bulldogs
         'https://afltables.com/afl/stats/alltime/university.html'
     ]
     PLAYER_COL_TITLES: List[str] = [


### PR DESCRIPTION
## Summary
- fix Western Bulldogs URL in `player_scraper.py`
- ensure no other URLs contain the typo

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cudf')*


------
https://chatgpt.com/codex/tasks/task_e_6840dba62180832487318808bb6cf09a